### PR TITLE
Add Ruby support for `crew-mvdir`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ cc ./crew-mvdir.c -O2 -o crew-mvdir
 ```
 
 ## License
-Copyright (C) 2013-2023 Chromebrew Authors
+Copyright (C) 2013-2024 Chromebrew Authors
 
 This project including all of its source files is released under the terms of [GNU General Public License (version 3 or later)](http://www.gnu.org/licenses/gpl.txt).

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -ex
+
+mkdir -p builddir
+cd builddir
+
+# build shared library
+cc -shared -fPIC ${CFLAGS} ../src/mvdir.c -o crew-mvdir.so.1
+
+# build CLI for use in install.sh
+cc ${CFLAGS} -L . -l:crew-mvdir.so.1 ../src/main.c -o crew-mvdir
+
+# build ruby binding for use in crew
+ruby ../src/ruby_binding/extconf.rb
+make -j"$(nproc)"
+
+echo 'Build completed.'

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,72 @@
+/*
+  Copyright (C) 2013-2024 Chromebrew Authors
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html.
+*/
+
+/*
+  crew-mvdir: Move all files under one directory to another,
+              override conflict files in the destination directory (merge two directories)
+
+  Equivalent of `rsync -ahHAXW --remove-source-files dir1/ dir2/`
+
+  crew-mvdir use rename() syscall to move files (instead of copying-deleting), that's why it is faster than `rsync`
+
+  Usage: ./crew-mvdir [-v] [-n] [src] [dst]
+
+  cc ./crew-mvdir.c -O2 -o crew-mvdir
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <unistd.h>
+#include "./mvdir.h"
+
+int main(int argc, char** argv) {
+  struct mvdir_opts *opts = calloc(1, sizeof opts);
+  int opt;
+
+  // initialize mvdir_opts struct
+  opts->src = calloc(sizeof(char), PATH_MAX);
+  opts->dst = calloc(sizeof(char), PATH_MAX);
+
+  while ((opt = getopt(argc, argv, "vn")) != -1) {
+    switch (opt) {
+      case 'v':
+        // verbose mode
+        opts->verbose = true;
+        break;
+      case 'n':
+        // do not overwrite an existing file
+        opts->no_clobber = true;
+        break;
+      default:
+        fprintf(stderr, "Usage: %s [-v] [-n] [src] [dst]\n", argv[0]);
+        exit(EXIT_FAILURE);
+        break;
+    }
+  }
+
+  if (argc - optind != 2) {
+    fprintf(stderr, "Usage: %s [-v] [-n] [src] [dst]\n", argv[0]);
+    exit(EXIT_FAILURE);
+  }
+
+  strcpy(opts->src, argv[optind]);
+  strcpy(opts->dst, argv[optind + 1]);
+
+  return move_directory(opts);
+}

--- a/src/mvdir.h
+++ b/src/mvdir.h
@@ -1,0 +1,26 @@
+/*
+  Copyright (C) 2013-2024 Chromebrew Authors
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html.
+*/
+
+#include <limits.h>
+#include <stdbool.h>
+
+struct mvdir_opts {
+  char *src, *dst;
+  bool same_fs, verbose, no_clobber;
+};
+
+int move_directory(struct mvdir_opts *optPtr);

--- a/src/ruby_binding/crew_mvdir.c
+++ b/src/ruby_binding/crew_mvdir.c
@@ -1,0 +1,56 @@
+/*
+  Copyright (C) 2013-2024 Chromebrew Authors
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.html.
+*/
+
+/*
+  ruby_binding/crew_mvdir.c: C binding for use in `crew`
+
+  Usage: crew_mvdir(src, dst, verbose: false)
+*/
+
+#include <string.h>
+#include <ruby.h>
+#include "../mvdir.h"
+
+VALUE crew_mvdir(int argc, VALUE *argv, VALUE self) {
+  struct mvdir_opts *opts = calloc(1, sizeof(opts));
+  VALUE src, dst, rb_opts, verbose;
+
+  // initialize mvdir_opts struct
+  opts->src = calloc(sizeof(char), PATH_MAX);
+  opts->dst = calloc(sizeof(char), PATH_MAX);
+
+  // parse argument passed in
+  rb_scan_args(argc, argv, "2:", &src, &dst, &rb_opts);
+
+  if (NIL_P(rb_opts)) rb_opts = rb_hash_new();
+
+  // read extra options
+  verbose = rb_hash_aref(rb_opts, rb_intern("verbose"));
+  if (NIL_P(verbose)) verbose = Qfalse;
+
+  // convert Ruby values to C style data types
+  strcpy(opts->src, StringValueCStr(src));
+  strcpy(opts->dst, StringValueCStr(dst));
+  opts->verbose = RTEST(verbose);
+
+  move_directory(opts);
+  return Qnil;
+}
+
+void Init_crew_mvdir() {
+  rb_define_global_function("crew_mvdir", crew_mvdir, -1);
+}

--- a/src/ruby_binding/crew_mvdir.c
+++ b/src/ruby_binding/crew_mvdir.c
@@ -16,7 +16,7 @@
 */
 
 /*
-  ruby_binding/crew_mvdir.c: C binding for use in `crew`
+  ruby_binding/crew_mvdir.c: Ruby binding for use in `crew`
 
   Usage: crew_mvdir(src, dst, verbose: false)
 */

--- a/src/ruby_binding/extconf.rb
+++ b/src/ruby_binding/extconf.rb
@@ -1,0 +1,5 @@
+require 'mkmf'
+
+$LDFLAGS += " -L#{Dir.pwd} -l:crew-mvdir.so.1"
+
+create_makefile 'crew_mvdir'


### PR DESCRIPTION
This PR adds native Ruby support to `crew-mvdir` by using Ruby's C API, which provides a more rubyize way to call `crew-mvdir` from inside of `crew`:

Before:
```ruby
system "crew-mvdir #{@verbose} #{src} #{dst}"
```

After:
```ruby
crew_mvdir src, dst, verbose: @verbose
```

Tested on `x86_64`